### PR TITLE
Modded sizes 00 and 0p5

### DIFF
--- a/GameData/VABOrganizer/Localization/en-us.cfg
+++ b/GameData/VABOrganizer/Localization/en-us.cfg
@@ -8,7 +8,7 @@ Localization
     // Stock and cylinders
     #LOC_VABOrganizer_Bulkhead_srf = SRF
     #LOC_VABOrganizer_Bulkhead_size0 = 0.625m
-    #LOC_VABOrganizer_Bulkhead_size0p5 = 0.625m
+    #LOC_VABOrganizer_Bulkhead_size0p5 = 0.9375m
     #LOC_VABOrganizer_Bulkhead_size1 = 1.25m
     #LOC_VABOrganizer_Bulkhead_size1p5 = 1.875m
     #LOC_VABOrganizer_Bulkhead_size2 = 2.5m
@@ -32,6 +32,7 @@ Localization
     // Mods
     #LOC_VABOrganizer_Bulkhead_size1p8 = 2.25m
     #LOC_VABOrganizer_Bulkhead_size1p2 = 1.5m
+    #LOC_VABOrganizer_Bulkhead_size00 = 0.3125m
     #LOC_VABOrganizer_Bulkhead_hex = HEX
     #LOC_VABOrganizer_Bulkhead_octo = OCT
     #LOC_VABOrganizer_Bulkhead_mk4 = MK4

--- a/GameData/VABOrganizer/bulkheadProfiles.cfg
+++ b/GameData/VABOrganizer/bulkheadProfiles.cfg
@@ -73,10 +73,24 @@ ORGANIZERBULKHEAD
 /// Cylinders
 ORGANIZERBULKHEAD
 {
+  name = size00
+  Size = 0.3125
+  Label = #LOC_VABOrganizer_Bulkhead_size00
+  Color = 0.7, 0.21, 0.35
+}
+ORGANIZERBULKHEAD
+{
+  name = size0p5
+  Size = 0.9375
+  Label = #LOC_VABOrganizer_Bulkhead_size0p5
+  Color = 0.7, 0.5, 0.21
+}
+ORGANIZERBULKHEAD
+{
   name = size1p2
   Size = 1.5
   Label = #LOC_VABOrganizer_Bulkhead_size1p2
-  Color = 0.511538461538462, 0.7, 0.21
+  Color = 0.62, 0.7, 0.21
 }
 ORGANIZERBULKHEAD
 {

--- a/GameData/VABOrganizer/bulkheadProfiles.cfg
+++ b/GameData/VABOrganizer/bulkheadProfiles.cfg
@@ -76,14 +76,14 @@ ORGANIZERBULKHEAD
   name = size00
   Size = 0.3125
   Label = #LOC_VABOrganizer_Bulkhead_size00
-  Color = 0.7, 0.21, 0.35
+  Color = 0.7, 0.21, 0.373333333333333
 }
 ORGANIZERBULKHEAD
 {
   name = size0p5
   Size = 0.9375
   Label = #LOC_VABOrganizer_Bulkhead_size0p5
-  Color = 0.7, 0.5, 0.21
+  Color = 0.7, 0.44, 0.21
 }
 ORGANIZERBULKHEAD
 {


### PR DESCRIPTION
These sizes are used over multiple mods each.
0p5/0.9375m is used in BDB, Tantares, CRE, KNES, KODS
00/0.3125m is used in BDB, Tantaers, KNES, RLA, and some sounding rocket mods
Also made 1.5m have a unique colour between 1.25 and 1.875

The extra character in the label seems fine to me, I'd prefer keeping the full size over rounding the label to 3 decimals.

(11pt text on my 1600p screen)
![image](https://github.com/post-kerbin-mining-corporation/VABOrganizer/assets/2611674/a3a51eff-173a-4f1c-80b3-6e3e8975432f)

It seems like only BDB uses 3p4/4.25m so I'll just include that as a patch on BDB's side. Same with size000

Colours:
.9375m is 28deg off red for H, with S/V of 70%, to be between .625 and 1.25
.3125m is 20deg off red, wrapped around (340deg, same colour as 10m)
1.5m is 15deg off 1.25m (70deg) to be between 1.25m and 1.875m