### PR TITLE
Reprioritize subcategories for mixed categories

### DIFF
--- a/GameData/VABOrganizer/Subcategories/aero.cfg
+++ b/GameData/VABOrganizer/Subcategories/aero.cfg
@@ -1,42 +1,44 @@
+///Aero
+///Priority Prefix 800
 ORGANIZERSUBCATEGORY
 {
-  /// Wings and things
-  name = wings
-  Label = #LOC_VABOrganizer_Subcategory_wings
-  Priority = 20
-}
-ORGANIZERSUBCATEGORY
-{
-  /// Wings that turn, generally
-  name = controlSurfaces
-  Label = #LOC_VABOrganizer_Subcategory_controlSurfaces
-  Priority = 25
-}
-ORGANIZERSUBCATEGORY
-{
-  /// Things that turn and deploy
-  name = deployableControlSurfaces
-  Label = #LOC_VABOrganizer_Subcategory_deployableControlSurfaces
-  Priority = 35
+  // air intakes
+  name = intakes
+  Label = #LOC_VABOrganizer_Subcategory_intakes
+  Priority = 810
 }
 ORGANIZERSUBCATEGORY
 {
   /// nosecones
   name = noses
   Label = #LOC_VABOrganizer_Subcategory_noses
-  Priority = 15
+  Priority = 820
 }
 ORGANIZERSUBCATEGORY
 {
-  // air intakes
-  name = intakes
-  Label = #LOC_VABOrganizer_Subcategory_intakes
-  Priority = 5
+  /// Wings and things
+  name = wings
+  Label = #LOC_VABOrganizer_Subcategory_wings
+  Priority = 830
+}
+ORGANIZERSUBCATEGORY
+{
+  /// Wings that turn, generally
+  name = controlSurfaces
+  Label = #LOC_VABOrganizer_Subcategory_controlSurfaces
+  Priority = 840
+}
+ORGANIZERSUBCATEGORY
+{
+  /// Things that turn and deploy
+  name = deployableControlSurfaces
+  Label = #LOC_VABOrganizer_Subcategory_deployableControlSurfaces
+  Priority = 850
 }
 ORGANIZERSUBCATEGORY
 {
   // BG: rotor blades
   name = rotorBlades
   Label = #LOC_VABOrganizer_Subcategory_rotorBlades
-  Priority = 50
+  Priority = 860
 }

--- a/GameData/VABOrganizer/Subcategories/cargo.cfg
+++ b/GameData/VABOrganizer/Subcategories/cargo.cfg
@@ -1,12 +1,14 @@
-ORGANIZERSUBCATEGORY
-{
-  name = cargoStorage
-  Label = #LOC_VABOrganizer_Subcategory_cargoStorage
-  Priority = 40
-}
+///Cargo
+///Priority Prefix 1400
 ORGANIZERSUBCATEGORY
 {
   name = deployables
   Label = #LOC_VABOrganizer_Subcategory_deployable
-  Priority = 20
+  Priority = 1410
+}
+ORGANIZERSUBCATEGORY
+{
+  name = cargoStorage
+  Label = #LOC_VABOrganizer_Subcategory_cargoStorage
+  Priority = 1420
 }

--- a/GameData/VABOrganizer/Subcategories/command.cfg
+++ b/GameData/VABOrganizer/Subcategories/command.cfg
@@ -1,37 +1,39 @@
+///Command
+///Priority Prefix 0
 ORGANIZERSUBCATEGORY
 {
   // command pods
   name = pods
   Label = #LOC_VABOrganizer_Subcategory_pods
-  Priority = 5
-}
-ORGANIZERSUBCATEGORY
-{
-  // Landing-focused command pods
-  name = landers
-  Label = #LOC_VABOrganizer_Subcategory_landers
-  Priority = 15
-}
-ORGANIZERSUBCATEGORY
-{
-  // probes
-  name = probes
-  Label = #LOC_VABOrganizer_Subcategory_probes
-  Priority = 20
+  Priority = 10
 }
 ORGANIZERSUBCATEGORY
 {
   // aircraft cockpits
   name = cockpits
   Label = #LOC_VABOrganizer_Subcategory_cockpits
-  Priority = 10
+  Priority = 20
+}
+ORGANIZERSUBCATEGORY
+{
+  // Landing-focused command pods
+  name = landers
+  Label = #LOC_VABOrganizer_Subcategory_landers
+  Priority = 30
+}
+ORGANIZERSUBCATEGORY
+{
+  // probes
+  name = probes
+  Label = #LOC_VABOrganizer_Subcategory_probes
+  Priority = 40
 }
 ORGANIZERSUBCATEGORY
 {
   // station cores
   name = station
   Label = #LOC_VABOrganizer_Subcategory_stationCores
-  Priority = 25
+  Priority = 50
 }
 
 

--- a/GameData/VABOrganizer/Subcategories/communication.cfg
+++ b/GameData/VABOrganizer/Subcategories/communication.cfg
@@ -1,19 +1,21 @@
+///Communication
+///Priority Prefix 1200
 ORGANIZERSUBCATEGORY
 {
   // antennas of the direct variety
   name = direct
   Label = #LOC_VABOrganizer_Subcategory_direct
-  Priority = 40
+  Priority = 1210
 }
 ORGANIZERSUBCATEGORY
 {
   name = relay
   Label = #LOC_VABOrganizer_Subcategory_relay
-  Priority = 50
+  Priority = 1220
 }
 ORGANIZERSUBCATEGORY
 {
   name = reflector
   Label = #LOC_VABOrganizer_Subcategory_reflector
-  Priority = 60
+  Priority = 1230
 }

--- a/GameData/VABOrganizer/Subcategories/control.cfg
+++ b/GameData/VABOrganizer/Subcategories/control.cfg
@@ -1,12 +1,14 @@
+///Control
+///Priority Prefix 300
 ORGANIZERSUBCATEGORY
 {
   name = rcs
   Label = #LOC_VABOrganizer_Subcategory_rcs
-  Priority = 8
+  Priority = 310
 }
 ORGANIZERSUBCATEGORY
 {
   name = sas
   Label = #LOC_VABOrganizer_Subcategory_reactionWheels
-  Priority = 15
+  Priority = 320
 }

--- a/GameData/VABOrganizer/Subcategories/coupling.cfg
+++ b/GameData/VABOrganizer/Subcategories/coupling.cfg
@@ -1,28 +1,30 @@
-ORGANIZERSUBCATEGORY
-{
-  /// Docking ports
-  name = dockingPorts
-  Label = #LOC_VABOrganizer_Subcategory_dockingPorts
-  Priority = 25
-}
+///Coupling
+///Priority Prefix 600
 ORGANIZERSUBCATEGORY
 {
   /// Decouplers
   name = decouplers
   Label = #LOC_VABOrganizer_Subcategory_decouplers
-  Priority = 8
+  Priority = 610
 }
 ORGANIZERSUBCATEGORY
 {
   /// Separators
   name = separators
   Label = #LOC_VABOrganizer_Subcategory_separators
-  Priority = 15
+  Priority = 620
+}
+ORGANIZERSUBCATEGORY
+{
+  /// Docking ports
+  name = dockingPorts
+  Label = #LOC_VABOrganizer_Subcategory_dockingPorts
+  Priority = 630
 }
 ORGANIZERSUBCATEGORY
 {
   /// Grappling
   name = grapples
   Label = #LOC_VABOrganizer_Subcategory_grapples
-  Priority = 30
+  Priority = 640
 }

--- a/GameData/VABOrganizer/Subcategories/electrical.cfg
+++ b/GameData/VABOrganizer/Subcategories/electrical.cfg
@@ -1,30 +1,32 @@
+///Electrical
+///Priority Prefix 1100
 ORGANIZERSUBCATEGORY
 {
   name = batteries
   Label = #LOC_VABOrganizer_Subcategory_batteries
-  Priority = 5
+  Priority = 1110
 }
 ORGANIZERSUBCATEGORY
 {
   name = solarPanels
   Label = #LOC_VABOrganizer_Subcategory_solarPanels
-  Priority = 20
-}
-ORGANIZERSUBCATEGORY
-{
-  name = fuelCells
-  Label = #LOC_VABOrganizer_Subcategory_fuelcells
-  Priority = 45
+  Priority = 1120
 }
 ORGANIZERSUBCATEGORY
 {
   name = nuclearReactors
   Label = #LOC_VABOrganizer_Subcategory_fissionReactors
-  Priority = 30
+  Priority = 1130
+}
+ORGANIZERSUBCATEGORY
+{
+  name = fuelCells
+  Label = #LOC_VABOrganizer_Subcategory_fuelcells
+  Priority = 1140
 }
 ORGANIZERSUBCATEGORY
 {
   name = rtgs
   Label = #LOC_VABOrganizer_Subcategory_rtgs
-  Priority = 90
+  Priority = 1150
 }

--- a/GameData/VABOrganizer/Subcategories/engines.cfg
+++ b/GameData/VABOrganizer/Subcategories/engines.cfg
@@ -1,49 +1,51 @@
+///Engines
+///Priority Prefix 200
 ORGANIZERSUBCATEGORY
 {
   name = lfoEngines
   Label = #LOC_VABOrganizer_Subcategory_lfoEngines
-  Priority = 5
+  Priority = 210
 }
 ORGANIZERSUBCATEGORY
 {
   /// boosters
   name = solidEngines
   Label = #LOC_VABOrganizer_Subcategory_solidEngines
-  Priority = 25
+  Priority = 220
+}
+ORGANIZERSUBCATEGORY
+{
+  name = nuclearEngines
+  Label = #LOC_VABOrganizer_Subcategory_nuclearEngines
+  Priority = 230
 }
 ORGANIZERSUBCATEGORY
 {
   /// Jet engines
   name = jetEngines
   Label = #LOC_VABOrganizer_Subcategory_jetEngines
-  Priority = 75
-}
-ORGANIZERSUBCATEGORY
-{
-  name = nuclearEngines
-  Label = #LOC_VABOrganizer_Subcategory_nuclearEngines
-  Priority = 50
+  Priority = 240
 }
 ORGANIZERSUBCATEGORY
 {
   /// monoprop engines
   name = monoEngines
   Label = #LOC_VABOrganizer_Subcategory_monoEngines
-  Priority = 90
+  Priority = 250
 }
 ORGANIZERSUBCATEGORY
 {
   /// xenon engines
   name = xenonEngines
   Label = #LOC_VABOrganizer_Subcategory_xenonEngines
-  Priority = 150
+  Priority = 260
 }
 ORGANIZERSUBCATEGORY
 {
   /// argon engines
   name = argonEngines
   Label = #LOC_VABOrganizer_Subcategory_argonEngines
-  Priority = 160
+  Priority = 270
 }
 
 

--- a/GameData/VABOrganizer/Subcategories/fuel.cfg
+++ b/GameData/VABOrganizer/Subcategories/fuel.cfg
@@ -1,24 +1,26 @@
+///Fuel
+///Priority Prefix 100
 ORGANIZERSUBCATEGORY
 {
   name = lfo
   Label = #LOC_VABOrganizer_Subcategory_lfo
-  Priority = 10
+  Priority = 110
 }
 ORGANIZERSUBCATEGORY
 {
   name = lf
   Label = #LOC_VABOrganizer_Subcategory_lf
-  Priority = 50
-}
-ORGANIZERSUBCATEGORY
-{
-  name = xenon
-  Label = #LOC_VABOrganizer_Subcategory_xenon
-  Priority = 80
+  Priority = 120
 }
 ORGANIZERSUBCATEGORY
 {
   name = monoprop
   Label = #LOC_VABOrganizer_Subcategory_monoprop
-  Priority = 70
+  Priority = 130
+}
+ORGANIZERSUBCATEGORY
+{
+  name = xenon
+  Label = #LOC_VABOrganizer_Subcategory_xenon
+  Priority = 140
 }

--- a/GameData/VABOrganizer/Subcategories/ground.cfg
+++ b/GameData/VABOrganizer/Subcategories/ground.cfg
@@ -1,20 +1,22 @@
+///Ground
+///Priority Prefix 900
 ORGANIZERSUBCATEGORY
 {
   name = legs
   Label = #LOC_VABOrganizer_Subcategory_legs
-  Priority = 8
+  Priority = 910
 }
 
 ORGANIZERSUBCATEGORY
 {
   name = wheels
   Label = #LOC_VABOrganizer_Subcategory_wheels
-  Priority = 16
+  Priority = 920
 }
 
 ORGANIZERSUBCATEGORY
 {
   name = gear
   Label = #LOC_VABOrganizer_Subcategory_gear
-  Priority = 24
+  Priority = 930
 }

--- a/GameData/VABOrganizer/Subcategories/payload.cfg
+++ b/GameData/VABOrganizer/Subcategories/payload.cfg
@@ -1,24 +1,26 @@
+///Payload
+///Priority Prefix 700
 ORGANIZERSUBCATEGORY
 {
   name = fairings
   Label = #LOC_VABOrganizer_Subcategory_fairings
-  Priority = 8
+  Priority = 710
 }
 ORGANIZERSUBCATEGORY
 {
   name = serviceBays
   Label = #LOC_VABOrganizer_Subcategory_serviceBays
-  Priority = 20
+  Priority = 720
 }
 ORGANIZERSUBCATEGORY
 {
   name = cargoBays
   Label = #LOC_VABOrganizer_Subcategory_cargoBays
-  Priority = 25
+  Priority = 730
 }
 ORGANIZERSUBCATEGORY
 {
   name = cargoContainers
   Label = #LOC_VABOrganizer_Subcategory_cargoContainers
-  Priority = 30
+  Priority = 740
 }

--- a/GameData/VABOrganizer/Subcategories/robotics.cfg
+++ b/GameData/VABOrganizer/Subcategories/robotics.cfg
@@ -1,18 +1,20 @@
+///Robotics
+///Priority Prefix 500
 ORGANIZERSUBCATEGORY
 {
   name = hinges
   Label = #LOC_VABOrganizer_Subcategory_hinges
-  Priority = 5
+  Priority = 510
 }
 ORGANIZERSUBCATEGORY
 {
   name = pistons
   Label = #LOC_VABOrganizer_Subcategory_pistons
-  Priority = 15
+  Priority = 520
 }
 ORGANIZERSUBCATEGORY
 {
   name = rotors
   Label = #LOC_VABOrganizer_Subcategory_rotors
-  Priority = 20
+  Priority = 530
 }

--- a/GameData/VABOrganizer/Subcategories/science.cfg
+++ b/GameData/VABOrganizer/Subcategories/science.cfg
@@ -1,30 +1,32 @@
+///Science
+///Priority Prefix 1300
 ORGANIZERSUBCATEGORY
 {
   name = science
   Label = #LOC_VABOrganizer_Subcategory_instruments
-  Priority = 5
+  Priority = 1310
 }
 ORGANIZERSUBCATEGORY
 {
   name = labs
   Label = #LOC_VABOrganizer_Subcategory_labs
-  Priority = 10
-}
-ORGANIZERSUBCATEGORY
-{
-  name = scienceStorage
-  Label = #LOC_VABOrganizer_Subcategory_scienceStorage
-  Priority = 20
-}
-ORGANIZERSUBCATEGORY
-{
-  name = resourceScanners
-  Label = #LOC_VABOrganizer_Subcategory_resourceScanners
-  Priority = 30
+  Priority = 1320
 }
 ORGANIZERSUBCATEGORY
 {
   name = greenhouses
   Label = #LOC_VABOrganizer_Subcategory_greenhouses
-  Priority = 15
+  Priority = 1330
+}
+ORGANIZERSUBCATEGORY
+{
+  name = scienceStorage
+  Label = #LOC_VABOrganizer_Subcategory_scienceStorage
+  Priority = 1340
+}
+ORGANIZERSUBCATEGORY
+{
+  name = resourceScanners
+  Label = #LOC_VABOrganizer_Subcategory_resourceScanners
+  Priority = 1350
 }

--- a/GameData/VABOrganizer/Subcategories/structural.cfg
+++ b/GameData/VABOrganizer/Subcategories/structural.cfg
@@ -1,42 +1,44 @@
-ORGANIZERSUBCATEGORY
-{
-  name = trusses
-  Label = #LOC_VABOrganizer_Subcategory_truss
-  Priority = 15
-}
+///Structural
+///Priority Prefix 400
 ORGANIZERSUBCATEGORY
 {
   name = adapters
   Label = #LOC_VABOrganizer_Subcategory_adapters
-  Priority = 10
+  Priority = 410
 }
 ORGANIZERSUBCATEGORY
 {
-  name = engineMount
-  Label = #LOC_VABOrganizer_Subcategory_engineMounts
-  Priority = 60
+  name = trusses
+  Label = #LOC_VABOrganizer_Subcategory_truss
+  Priority = 420
 }
 ORGANIZERSUBCATEGORY
 {
   name = girders
   Label = #LOC_VABOrganizer_Subcategory_girders
-  Priority = 25
-}
-ORGANIZERSUBCATEGORY
-{
-  name = hubs
-  Label = #LOC_VABOrganizer_Subcategory_hubs
-  Priority = 100
-}
-ORGANIZERSUBCATEGORY
-{
-  name = multicouplers
-  Label = #LOC_VABOrganizer_Subcategory_multicouplers
-  Priority = 150
+  Priority = 430
 }
 ORGANIZERSUBCATEGORY
 {
   name = tubes
   Label = #LOC_VABOrganizer_Subcategory_tubes
-  Priority = 40
+  Priority = 440
+}
+ORGANIZERSUBCATEGORY
+{
+  name = engineMount
+  Label = #LOC_VABOrganizer_Subcategory_engineMounts
+  Priority = 450
+}
+ORGANIZERSUBCATEGORY
+{
+  name = hubs
+  Label = #LOC_VABOrganizer_Subcategory_hubs
+  Priority = 460
+}
+ORGANIZERSUBCATEGORY
+{
+  name = multicouplers
+  Label = #LOC_VABOrganizer_Subcategory_multicouplers
+  Priority = 470
 }

--- a/GameData/VABOrganizer/Subcategories/thermal.cfg
+++ b/GameData/VABOrganizer/Subcategories/thermal.cfg
@@ -1,12 +1,14 @@
+///Thermal
+///Priority Prefix 1000
 ORGANIZERSUBCATEGORY
 {
   name = heatShields
   Label = #LOC_VABOrganizer_Subcategory_heatShields
-  Priority = 5
+  Priority = 1010
 }
 ORGANIZERSUBCATEGORY
 {
   name = radiators
   Label = #LOC_VABOrganizer_Subcategory_radiators
-  Priority = 15
+  Priority = 1020
 }

--- a/GameData/VABOrganizer/Subcategories/utility.cfg
+++ b/GameData/VABOrganizer/Subcategories/utility.cfg
@@ -1,48 +1,50 @@
+///Utility
+///Priority Prefix 1500
 ORGANIZERSUBCATEGORY
 {
   name = parachutes
-  Priority = 5
+  Priority = 1510
   Label = #LOC_VABOrganizer_Subcategory_parachutes
-}
-ORGANIZERSUBCATEGORY
-{
-  name = resources
-  Priority = 80
-  Label = #LOC_VABOrganizer_Subcategory_resources
-}
-ORGANIZERSUBCATEGORY
-{
-  name = lights
-  Label = #LOC_VABOrganizer_Subcategory_lights
-  Priority = 100
 }
 ORGANIZERSUBCATEGORY
 {
   name = ladders
   Label = #LOC_VABOrganizer_Subcategory_ladders
-  Priority = 60
+  Priority = 1520
+}
+ORGANIZERSUBCATEGORY
+{
+  name = resources
+  Priority = 1530
+  Label = #LOC_VABOrganizer_Subcategory_resources
 }
 ORGANIZERSUBCATEGORY
 {
   name = crewTransport
   Label = #LOC_VABOrganizer_Subcategory_crewTransport
-  Priority = 80
+  Priority = 1540
 }
 ORGANIZERSUBCATEGORY
 {
   name = crewHabitation
   Label = #LOC_VABOrganizer_Subcategory_crewHabitation
-  Priority =85
+  Priority = 1550
 }
 ORGANIZERSUBCATEGORY
 {
   name = airlocks
   Label = #LOC_VABOrganizer_Subcategory_airlocks
-  Priority = 90
+  Priority = 1560
+}
+ORGANIZERSUBCATEGORY
+{
+  name = lights
+  Label = #LOC_VABOrganizer_Subcategory_lights
+  Priority = 1570
 }
 ORGANIZERSUBCATEGORY
 {
   name = flags
   Label = #LOC_VABOrganizer_Subcategory_flags
-  Priority = 110
+  Priority = 1580
 }


### PR DESCRIPTION
With this, each category has a priority prefix, corresponding to in-game category order, so subcategories still sort into the defined order in categories with parts from mixed stock categories, eg with custom CCK categories, or stock categories with modded parts. Maintains current in-category sorting.

Sorted subcategories into priority order in the cfgs.