### PR TITLE
Recategorize avionics nosecone as SAS

### DIFF
--- a/GameData/VABOrganizer/SubcategoryPatches/stock.cfg
+++ b/GameData/VABOrganizer/SubcategoryPatches/stock.cfg
@@ -99,11 +99,18 @@
 }
 /// Control
 /// -------------
-@PART[asasmodule1-2|sasModule|avionicsNoseCone|advSasModule]:FOR[VABOrganizer]
+@PART[asasmodule1-2|sasModule|advSasModule]:FOR[VABOrganizer]
 {
   %VABORGANIZER
   {
     %organizerSubcategory = reactionWheels
+  }
+}
+@PART[avionicsNoseCone]:FOR[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = sas
   }
 }
 @PART[RCSBlock_v2|RCSblock_01_small|RCSLinearSmall|vernierEngine|linearRcs]:FOR[VABOrganizer]


### PR DESCRIPTION
Avionics package was categorized as a reaction wheel but actually provides SAS instead. 