### PR TITLE
Fix ArgumentOutOfRangeException when adding subassemblies

### DIFF
--- a/Source/VABOrganizer/AdvancedSorting.cs
+++ b/Source/VABOrganizer/AdvancedSorting.cs
@@ -203,6 +203,12 @@ namespace VABOrganizer
     /// </summary>
     public static void Refresh()
     {
+      // Fix for Subassemblies UI crash
+      if (uiPartList.CategorizerFilters == null || uiPartList.CategorizerFilters.Count == 0)
+      {
+        Utils.Log("[Advanced Sorting] CategorizerFilters is empty. Skipping refresh.");
+        return;
+      }
       string currentCategorySort = uiPartList.CategorizerFilters[0].ID;
       Utils.Log($"[Advanced Sorting] Refreshed, new categoryFilter is {currentCategorySort}, from {cachedCategorySort}");
       if (SortWidget != null)


### PR DESCRIPTION
I didn't dig into it, but it probably because subassemblies do not have filters. The exception breaks the Harmony patch chain, which in turn halts the main KSP.UI.Screens.EditorPartList.Refresh() method. The UI stops updating entirely.

The patch added a simple null check to stop refresh.